### PR TITLE
Updated README.md with working example resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,19 +72,19 @@ module.exports = [
   // ...
   {
     filename: 'ios/<YourAppName>/Info.plist',
-    updater: require.resolve('standard-version-expo/ios/native/app-version'),
+    updater: require.resolve('@brettdh/standard-version-expo/ios/native/app-version'),
   },
   {
     filename: 'ios/<YourAppName>/Info.plist',
-    updater: require.resolve('standard-version-expo/ios/native/buildnum/increment'),
+    updater: require.resolve('@brettdh/standard-version-expo/ios/native/buildnum/increment'),
   },
   {
     filename: 'android/app/build.gradle',
-    updater: require.resolve('standard-version-expo/android/native/app-version'),
+    updater: require.resolve('@brettdh/standard-version-expo/android/native/app-version'),
   },
   {
     filename: 'android/app/build.gradle',
-    updater: require.resolve('standard-version-expo/android/native/buildnum/code')(sdkVersion),
+    updater: require('@brettdh/standard-version-expo/android/native/buildnum/code')(sdkVersion),
   },
 ];
 ```


### PR DESCRIPTION
The current example for Bare Workflow resolvers does not work. This is because the additional resolvers are not included with the `standard-version-expo` package. They are only available from this repo, which needs to be specified when requiring the updater.

Also, the `android/app/build.gradle` updater should not use `require.resolve` as we resolve it when calling it with the `sdkVersion` as a parameter.
